### PR TITLE
Remove all authorized keys from the machine

### DIFF
--- a/scripts/linux/MetaDefenderMarketplaceAMIUserData.sh
+++ b/scripts/linux/MetaDefenderMarketplaceAMIUserData.sh
@@ -49,4 +49,5 @@ else
 fi;
 EOF
 
+sudo rm -f /home/ec2-user/.ssh/authorized_keys
 sudo chmod 555 ${BOOT_SCRIPT_FILE}


### PR DESCRIPTION
No authorized keys should be saved on the AMI before submitting for AWS Marketplace review